### PR TITLE
Fix shader to generate correct texture coordinates.

### DIFF
--- a/drm_mmal.c
+++ b/drm_mmal.c
@@ -949,7 +949,7 @@ gl_setup(void)
       "void main() {\n"
       "  gl_Position = pos;\n"
       "  texcoord.x = (pos.x + 1.0) / 2.0;\n"
-      "  texcoord.y = (pos.y + 1.0) / -2.0;\n"
+      "  texcoord.y = (pos.y - 1.0) / -2.0;\n"
       "}\n";
    GLint vs_s = compile_shader(GL_VERTEX_SHADER, vs);
    const char *fs =


### PR DESCRIPTION
This fixes a problem where the output shows only the top line of the video stretched over the entire height.